### PR TITLE
Add helper methods: withResults and buckets

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -141,4 +141,11 @@ class Response implements ArrayAccess, Countable
     {
         return $this->attributes;
     }
+
+    public function withResults(LengthAwarePaginator $results): self
+    {
+        $this->attributes->put('results', $results);
+
+        return $this;
+    }
 }

--- a/src/Response/Delegates.php
+++ b/src/Response/Delegates.php
@@ -2,6 +2,8 @@
 
 namespace Datashaman\Elasticsearch\Model\Response;
 
+use Illuminate\Support\Collection;
+
 trait Delegates
 {
     /**
@@ -40,6 +42,11 @@ trait Delegates
     public function aggregations()
     {
         return array_get($this->response(), 'aggregations');
+    }
+
+    public function buckets(string $name): Collection
+    {
+        return collect(array_get($this->response(), "aggregations.{$name}.buckets", []));
     }
 
     public function total()


### PR DESCRIPTION
* `withResults` for use-cases where the results must be replaced by a custom-made paginator.
* `buckets` to get a collection of buckets by name.